### PR TITLE
Use remote theme for just-the-docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Update dependencies.[#2](https://github.com/ausaccessfed/dev-portal/pull/2)
+- Use remote theme.[#3](https://github.com/ausaccessfed/dev-portal/pull/3)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -79,7 +79,7 @@ footer_content: "Copyright &copy; 2023 The Australian Access Federation."
 
 
 # Build settings
-theme: just-the-docs
+remote_theme: just-the-docs
 plugins:
   - jekyll-feed
 


### PR DESCRIPTION
It seems that GitHub Pages only supports a few themes. https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/adding-a-theme-to-your-github-pages-site-using-jekyll#adding-a-jekyll-theme-in-your-sites-_configyml-file

"To use any other Jekyll theme hosted on GitHub, type remote_theme: THEME-NAME, replacing THEME-NAME with the name of the theme as shown in the README of the theme's repository."

I've added "remote_theme" for just-the-docs to the config.yml to comply with this.