### PR TITLE
Add compose config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+up:
+	docker-compose up -d
+	@echo "jekyll site is running at http://localhost:4000"
+
+down:
+	docker-compose down

--- a/README.md
+++ b/README.md
@@ -3,20 +3,21 @@
 
 [Jekyll](https://jekyllrb.com/) is a static site generator built as a Ruby gem. It requires Ruby and a Ruby version manager, such as [rbenv](https://github.com/rbenv/rbenv) or [chruby](https://github.com/postmodern/chruby), for installation. You can refer to the [Jekyll documentation](https://jekyllrb.com/docs/installation/macos/) for detailed installation instructions tailored to your operating system.
 
-## Using Docker
+## Using Docker Compose
 If you prefer a Docker-based setup, follow these steps:
 
-1. **Build the Docker Image**: Run the following command to build a new image of your Jekyll site:
+1. **Build and run Docker Image**: Run the following command to build a new image of your Jekyll site:
     ```bash
-    make build-image
-    ```
-
-2. **Run the Docker Container**: Once the image is built, you can run your site using Docker with the following command:
-    ```bash
-    make run-image
+    make up
     ```
 
 3. **View Your Site**: Open your web browser and navigate to [http://localhost:4000](http://localhost:4000) to view your Jekyll site running locally.
+   
+
+2. **Remove the Docker Image**: Once the image is built, you can run your site using Docker with the following command:
+    ```bash
+    make down
+    ```
 
 By using Docker, you can ensure consistent environments across different platforms and simplify the setup process for your Jekyll site.
 

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,7 @@
+services:
+  jekyll:
+    image: bretfisher/jekyll-serve
+    volumes:
+      - ./docs:/site
+    ports:
+      - '4000:4000'


### PR DESCRIPTION
The docker stuff was removed in https://github.com/ausaccessfed/dev-portal/pull/33, this adds a much simpler compose option via `make up` and `make down`. Since the volumes are mounted, any site changes should recompile without needing to restart the compose