### PR TITLE
Add test federation link for VerifID

### DIFF
--- a/docs/_connect-with-verifid/02-connect-verifid-service.md
+++ b/docs/_connect-with-verifid/02-connect-verifid-service.md
@@ -8,7 +8,11 @@ To register as a new client with VerifID Global:
 
 1. Contact [AAF Support](mailto:support@aaf.edu.au) first to discuss terms and conditions.
 
-2. [Register](https://manager.aaf.edu.au/verifid/register).
+2. Register your details in the Federation:
+- [Test Federation](https://manager.test.aaf.edu.au/verifid/register)
+- [Production Federation](https://manager.aaf.edu.au/verifid/register)
+
+{: .callout-info}
 
 Note: You will need an AAF account (e.g. VHO account) to access the above registration link. Contact [AAF Support](mailto:support@aaf.edu.au) to request an account or alternatively, send your registration details (i.e. Display Name and Redirect URI, as shown on the form below) to [AAF Support](mailto:support@aaf.edu.au).
 {: .callout-info}


### PR DESCRIPTION
Both test and production links need to be displayed on the verifID registration page.