### PR TITLE
Fix broken links

### DIFF
--- a/docs/_connect-a-rapid-connect-service/02-connect-rapid-connect-service.md
+++ b/docs/_connect-a-rapid-connect-service/02-connect-rapid-connect-service.md
@@ -17,8 +17,8 @@ png)
 
 1. Name - A descriptive name for your service.
 2. URL - The primary URL of your application which users would enter into the browser to visit your application. This value is provided to your application as the **aud** claim.
-3. Callback URL - The secure URL within your application that AAF Rapid Connect should POST completed responses to. We described this endpoint as part of the [Integration Steps](/rapid-connect-integration/06-integration).
-4. Secret - Must be random and securely stored by the service. This value should never be publicly disclosed and is used by the service to verify signed tokens from AAF Rapid Connect. We generated this as part of the [Integration Steps](/rapid-connect-integration/06-integration).
+3. Callback URL - The secure URL within your application that AAF Rapid Connect should POST completed responses to. We described this endpoint as part of the [Integration Steps](/rapid-connect-integration/07-integration).
+4. Secret - Must be random and securely stored by the service. This value should never be publicly disclosed and is used by the service to verify signed tokens from AAF Rapid Connect. We generated this as part of the [Integration Steps](/rapid-connect-integration/07-integration).
 5. Organisation - The AAF subscribed organisation which is sponsoring this service.
 
 - Click **Register Service** to complete the registration step.

--- a/docs/_connect-a-rapid-connect-service/03-test-authentication.md
+++ b/docs/_connect-a-rapid-connect-service/03-test-authentication.md
@@ -7,7 +7,7 @@ duration: 1
 Since you have registered your service in the Test Federation, your application will be automatically approved!
 {: .callout-success }
 
-The completion screen will show the unique URL for your application to initiate login. You can use this immediately with your application to start the authentication process as we discussed in [Standard Flow](/rapid-connect-integration/03-standard-flow).
+The completion screen will show the unique URL for your application to initiate login. You can use this immediately with your application to start the authentication process as we discussed in [Standard Flow](/rapid-connect-integration/04-standard-flow).
 
 ![Approved Rapid Connect](/assets/images/connect-a-rapid-connect-service/approved-rapid-connect.png)
 


### PR DESCRIPTION
## Description

<!-- Provide a clear description of your pull request. Make sure to include the tutorial title and a reason for your suggested changes/additions. If it is related to an issue, please reference the issue number, like `#1234`. -->

Updating the rapid connect tutorials has caused some of the links to break. Have updated them.