### PR TITLE
Update new service links

### DIFF
--- a/docs/_connect-a-rapid-connect-service/02-connect-rapid-connect-service.md
+++ b/docs/_connect-a-rapid-connect-service/02-connect-rapid-connect-service.md
@@ -8,7 +8,7 @@ last_updated: 29 January, 2025
 If you have not done so already, please [log in to Federation Manager](/log-into-federation-manager/01-overview) to get started.
 {: .callout-info }
 
-Once you have logged into Federation Manager and are on the ['Connect a New Service'](https://manager.test.aaf.edu.au/connected_services/new) page, click on 'Rapid Connect'. You will then be taken to the **Register a New Service** 
+Once you have logged into Federation Manager and are on the ['Connect a New Service'](https://manager.test.aaf.edu.au/services/new) page, click on 'Rapid Connect'. You will then be taken to the **Register a New Service** 
 page:
 
 ![Register new rapid connect service](/assets/images/connect-a-rapid-connect-service/register-new-rapid-connect-service.

--- a/docs/_connect-a-saml-service/02-connect-saml-service.md
+++ b/docs/_connect-a-saml-service/02-connect-saml-service.md
@@ -10,7 +10,7 @@ A deployed Shibboleth Service Provider (SP) only becomes useful after registerin
 ---
 If you have not done so already, please [log in to Federation Manager](/log-into-federation-manager/01-overview) to get started.
 
-Once you have clicked on 'SAML' on the ['Connect a New Service'](https://manager.test.aaf.edu.au/connected_services/new) page, you will then be taken to the **Register a SAML Service Provider** page:
+Once you have clicked on 'SAML' on the ['Connect a New Service'](https://manager.test.aaf.edu.au/services/new) page, you will then be taken to the **Register a SAML Service Provider** page:
 
 ![Register new saml service](/assets/images/connect-a-saml-service/register-new-saml-service.png)
 

--- a/docs/_connect-an-oidc-service/02-connect-oidc-service.md
+++ b/docs/_connect-an-oidc-service/02-connect-oidc-service.md
@@ -10,7 +10,7 @@ The **AAF OpenID Provider (OP)** satisfies the **OIDC** conformance testing fram
 ---
 If you have not done so already, please [log into Federation Manager](/log-into-federation-manager/01-overview) to get started.
 
-Once you have clicked on 'OpenID Connect' on the ['Connect a New Service'](https://manager.test.aaf.edu.au/connected_services/new) page in Federation Manager, you will then be taken to the **Register a New Service** page:
+Once you have clicked on 'OpenID Connect' on the ['Connect a New Service'](https://manager.test.aaf.edu.au/services/new) page in Federation Manager, you will then be taken to the **Register a New Service** page:
 
 ![Register new service](/assets/images/connect-an-oidc-service/register-oidc-service.png)
 


### PR DESCRIPTION
## Description

Reflects changes in Federation Manager in [this commit](https://github.com/ausaccessfed/federationmanager/commit/c62c796bb3670eb8579579cd8ede5ce27c14651c). The old link still works, but it's a redirect we'd like to remove.
<!-- Provide a clear description of your pull request. Make sure to include the tutorial title and a reason for your suggested changes/additions. If it is related to an issue, please reference the issue number, like `#1234`. -->

## Checklist:

- [x] I have confirmed that the content is not already covered in the tutorials available on the AAF Support Tutorials website 
- [x] I have tested the tutorial's content (including spelling, grammar and readability), links and images, and have not found any issues
- [ ] I have added my email address above and in the metadata of the tutorial