### PR TITLE
Remove font weight from headings

### DIFF
--- a/docs/assets/main.scss
+++ b/docs/assets/main.scss
@@ -25,7 +25,6 @@ main {
 h1, h2, h3, h4, h5, h6 {
   font-family: 'Inter', sans-serif;
   font-style: normal;
-  font-weight: 600;
 }
 
 .p {


### PR DESCRIPTION
## Description

<!-- Provide a clear description of your pull request. Make sure to include the tutorial title and a reason for your suggested changes/additions. If it is related to an issue, please reference the issue number, like `#1234`. -->
Headings on this page should be scaling down as a user scans down the page. However, the font-weight property is overriding this. This PR removes the font-weight property from the headings.


From this:
<img width="1902" height="932" alt="Screenshot 2025-10-20 at 17 06 39" src="https://github.com/user-attachments/assets/e556cd90-4cc9-477d-9c99-abc016997e3c" />


To this:
<img width="1902" height="932" alt="Screenshot 2025-10-20 at 17 07 26" src="https://github.com/user-attachments/assets/dd1cd5f2-8fb6-4f6c-954d-766016675b45" />
