### PR TITLE
Add current AAF attribute list to Rapid Connect Integration tutorial

### DIFF
--- a/docs/_rapid-connect-integration/02-interaction.md
+++ b/docs/_rapid-connect-integration/02-interaction.md
@@ -27,24 +27,7 @@ Once user session management is under control, additional flow controls can be i
 
 The AAF offers a set of core attributes each with varying uses. Although it is tempting to request a wide range of attributes to capture as much information as possible about users, only consider what is truly necessary to provide a service.
 
-The following attributes are available to Rapid Connect and the AAF recommends:
-- `eduPersonTargetedID` — This should be used as the primary identifier, to match an incoming user against an existing record in an application's data store. This attribute is guaranteed to never change for a user.
-
-- `displayName` — This is the most appropriate name to show in the web interface, to identify the user and show that they are logged in. Do not rely on any specific format for displayName. Attempts to validate names will create problems for those users who do not fit the chosen patterns and this will invariably occur.
-
-- `mail` — Only collect if there is a need to message the user, or use as a secondary identifier. 
-
-- `eduPersonScopedAffiliation` — Only collect if there is a need to identify the user's organisation and their affiliation or position within their organisation.
-
-- `eduPersonEntitlement` — Only collect if there is a need to identify specific entitlements assigned to the user.
-
-See the [Support Portal Attributes page](https://support.aaf.edu.au/support/solutions/folders/19000156050) for complete information and definitions of the AAF attributes available.
-
-The AAF strongly recommends that `eduPersonTargetedID` is chosen as the primary identifier rather than `email`. `Email` addresses change on an irregular basis for numerous reasons. When they inevitably do change, users experience service disruption while manual remediation work is undertaken to update primary identifiers. Home institutions will invariably not communicate email addresses updates to external parties.
-{: .callout-info}
-Though `auEduPersonSharedToken` is a core attribute, it is not recommended for general use or as a primary identifier. `auEduPersonSharedToken` is only useful in grid-computing environments, or to share user data or access rules across security domains or separate Service Providers.
-{: .callout-info}
-
+Refer to [Section 5](/rapid-connect-integration/05-provided-claims-and-attributes) of this tutorial for a list of claims and attributes provided by Rapid Connect.
 
 ### Consuming attributes injected by the SP
 

--- a/docs/_rapid-connect-integration/05-provided-claims-and-attributes.md
+++ b/docs/_rapid-connect-integration/05-provided-claims-and-attributes.md
@@ -1,5 +1,5 @@
 ---
-title: Provided Claims
+title: Provided Claims and Attributes
 order: 5
 duration: 1
 last_updated: 21 March, 2025
@@ -56,3 +56,40 @@ The following claims are provided by AAF Rapid Connect:
 </table>
 <br>
 Timestamps are defined by the specification as `IntDate` values, which are a JSON numeric value representing the number of seconds from 1970-01-01T0:0:0Z UTC until the specified UTC date/time.
+<br>
+<br>
+The following attributes are available to Rapid Connect and are recommended by the AAF. Only consider what is truly 
+necessary to provide a service. For a complete list of available AAF attributes, refer to the [AAF Support Portal Attributes](https://support.aaf.edu.au/support/solutions/folders/19000156050) page.
+
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th scope="col">Attribute</th>
+      <th scope="col">Definition</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+    <th scope="row">eduPersonTargetedID</th>
+      <td>This should be used as the primary identifier, to match an incoming user against an existing record in an application's data store. This attribute is guaranteed to never change for a user.
+</td>
+    </tr>
+    <tr>
+        <th scope="row">displayName</th>
+      <td>This is the most appropriate name to show in the web interface, to identify the user and show that they are logged in. Do not rely on any specific format for displayName. Attempts to validate names will create problems for those users who do not fit the chosen patterns and this will invariably occur.</td>
+    </tr>
+<tr>
+      <th scope="row">mail</th>
+      <td>Only collect if there is a need to message the user, or use as a secondary identifier. </td>
+    </tr>
+    <tr>
+      <th scope="row">eduPersonScopedAffiliation</th>
+      <td>Only collect if there is a need to identify the user's organisation and their affiliation or position within their organisation.</td>
+    </tr>
+  </tbody>
+</table>
+
+<br>
+The AAF strongly recommends that `eduPersonTargetedID` is chosen as the primary identifier rather than `email`. Email addresses change on an irregular basis for numerous reasons. When they inevitably do change, users experience service disruption while manual remediation work is undertaken to update primary identifiers. Home institutions will invariably not communicate email addresses updates to external parties.
+
+Though `auEduPersonSharedToken` is a core attribute, it is not recommended for general use or as a primary identifier. `auEduPersonSharedToken` is only useful in grid-computing environments, or to share user data or access rules across security domains or separate Service Providers.

--- a/docs/_rapid-connect-integration/05-provided-claims-and-attributes.md
+++ b/docs/_rapid-connect-integration/05-provided-claims-and-attributes.md
@@ -169,4 +169,7 @@ Though `auEduPersonSharedToken` is a core attribute, it is not recommended for g
 
 <br>
 
-See the [Support Portal Attributes page](https://support.aaf.edu.au/support/solutions/folders/19000156050) for complete information and definitions of the core, optional and conditional AAF attributes available.
+See the following links for complete information and definitions of the core, optional and conditional AAF attributes available:
+
+- [Support Portal Attributes page](https://support.aaf.edu.au/support/solutions/folders/19000156050)
+- [Validator Service](https://validator.aaf.edu.au/documentation/categories)

--- a/docs/_rapid-connect-integration/05-provided-claims-and-attributes.md
+++ b/docs/_rapid-connect-integration/05-provided-claims-and-attributes.md
@@ -5,7 +5,7 @@ duration: 1
 last_updated: 21 March, 2025
 ---
 
-The following claims are provided by AAF Rapid Connect:
+<strong>The following claims are provided by AAF Rapid Connect:</strong>
 
 <table class="table table-striped">
   <thead>
@@ -58,8 +58,21 @@ The following claims are provided by AAF Rapid Connect:
 Timestamps are defined by the specification as `IntDate` values, which are a JSON numeric value representing the number of seconds from 1970-01-01T0:0:0Z UTC until the specified UTC date/time.
 <br>
 <br>
-The following attributes are available to Rapid Connect and are recommended by the AAF. Only consider what is truly 
-necessary to provide a service. For a complete list of available AAF attributes, refer to the [AAF Support Portal Attributes](https://support.aaf.edu.au/support/solutions/folders/19000156050) page.
+<strong>The following attributes are available to Rapid Connect and the AAF recommends:</strong>
+- `eduPersonTargetedID` — This should be used as the primary identifier, to match an incoming user against an existing record in an application's data store. This attribute is guaranteed to never change for a user.
+
+- `displayName` — This is the most appropriate name to show in the web interface, to identify the user and show that they are logged in. Do not rely on any specific format for displayName. Attempts to validate names will create problems for those users who do not fit the chosen patterns and this will invariably occur.
+
+- `mail` — Only collect if there is a need to message the user, or use as a secondary identifier.
+
+- `eduPersonScopedAffiliation` — Only collect if there is a need to identify the user's organisation and their affiliation or position within their organisation.
+
+- `eduPersonEntitlement` — Only collect if there is a need to identify specific entitlements assigned to the user.
+
+The AAF strongly recommends that `eduPersonTargetedID` is chosen as the primary identifier rather than `email`. `Email` addresses change on an irregular basis for numerous reasons. When they inevitably do change, users experience service disruption while manual remediation work is undertaken to update primary identifiers. Home institutions will invariably not communicate email addresses updates to external parties.
+{: .callout-info}
+Though `auEduPersonSharedToken` is a core attribute, it is not recommended for general use or as a primary identifier. `auEduPersonSharedToken` is only useful in grid-computing environments, or to share user data or access rules across security domains or separate Service Providers.
+{: .callout-info}
 
 <table class="table table-striped">
   <thead>
@@ -69,27 +82,91 @@ necessary to provide a service. For a complete list of available AAF attributes,
     </tr>
   </thead>
   <tbody>
+<tr>
+    <th scope="row">authenticationMethod</th>
+      <td>Defines the method(s) used to verify the person's identity.
+</td>
+    </tr>
     <tr>
-    <th scope="row">eduPersonTargetedID</th>
-      <td>This should be used as the primary identifier, to match an incoming user against an existing record in an application's data store. This attribute is guaranteed to never change for a user.
+    <th scope="row">cn (commonName)</th>
+      <td>An individual's common name.
 </td>
     </tr>
     <tr>
         <th scope="row">displayName</th>
       <td>This is the most appropriate name to show in the web interface, to identify the user and show that they are logged in. Do not rely on any specific format for displayName. Attempts to validate names will create problems for those users who do not fit the chosen patterns and this will invariably occur.</td>
     </tr>
+    <tr>
+    <th scope="row">eduPersonOrcid</th>
+      <td>ORCID iDs are persistent digital identifiers for individual researchers. Their primary purpose is to unambiguously and definitively link them with their scholarly work products. ORCID iDs are assigned, managed and maintained by the ORCID organization. Values MUST be valid ORCID identifiers in the ORCID-preferred URL representation. Each value represents an ORCID identifier registered with ORCID.org as belonging to the principal.
+</td>
+    </tr>
+    <tr>
+    <th scope="row">eduPersonEntitlement</th>
+      <td>URI (either URN or URL) that indicates a set of rights to specific resources.
+</td>
+    </tr>
 <tr>
-      <th scope="row">mail</th>
-      <td>Only collect if there is a need to message the user, or use as a secondary identifier. </td>
+    <th scope="row">eduPersonPrincipalName</th>
+      <td>eduPerson per Internet2 and EDUCAUSE.
+</td>
     </tr>
     <tr>
       <th scope="row">eduPersonScopedAffiliation</th>
-      <td>Only collect if there is a need to identify the user's organisation and their affiliation or position within their organisation.</td>
+      <td>Specifies the person's relationship(s) to the institution in broad categories. Only collect if there is a need to identify the user's organisation and their affiliation or position within their organisation.</td>
     </tr>
-  </tbody>
+    <tr>
+      <th scope="row">auEduPersonSharedToken</th>
+      <td>A unique identifier enabling federation spanning services such as Grid and Repositories. Values of the identifier are generated using a set formula.[^1] Only collect if there is a need to share user data or access rules across security domains or separate Service Providers. This attribute is only useful in grid-computing environments.</td>
+    </tr>
+    <tr>
+    <th scope="row">eduPersonTargetedID</th>
+      <td>A persistent, non-reassigned, privacy-preserving identifier for a user shared between an identity provider and service provider. An identity provider uses the appropriate value of this attribute when communicating with a particular service provider or group of service providers, and does not reveal that value to any other service provider except in limited circumstances.
+</td>
+    </tr>
+<tr>
+    <th scope="row">eduPersonTargetedID</th>
+      <td>This should be used as the primary identifier, to match an incoming user against an existing record in an application's data store. This attribute is guaranteed to never change for a user.
+</td>
+    </tr>
+    <tr>
+    <th scope="row">givenName</th>
+      <td>Person's given or first name.
+</td>
+    </tr>
+<tr>
+    <th scope="row">mail</th>
+      <td>The person's public email address used to contact the person regarding matters related to their organisation. Only collect if there is a need to message the user, or use as a secondary identifier. </td>
+    </tr>
+    <tr>
+    <th scope="row">organizationName</th>
+      <td>The standard name of the top-level organization (institution) with which this person is associated. 
+</td>
+    </tr>
+<tr>
+    <th scope="row">surname</th>
+      <td>The person's surname.
+</td>
+    </tr>
+</tbody>
 </table>
 
 <br>
-The AAF strongly recommends that `eduPersonTargetedID` is chosen as the primary identifier rather than `email`. Email addresses change on an irregular basis for numerous reasons. When they inevitably do change, users experience service disruption while manual remediation work is undertaken to update primary identifiers. Home institutions will invariably not communicate email addresses updates to external parties.
 
-Though `auEduPersonSharedToken` is a core attribute, it is not recommended for general use or as a primary identifier. `auEduPersonSharedToken` is only useful in grid-computing environments, or to share user data or access rules across security domains or separate Service Providers.
+[^1] The value has the following qualities:
+
+  - unique
+  - opaque
+  - non-targeted
+  - persistent
+  - resolvable (only by an IdP that has supplied it)
+  - not re-assignable
+  - not mutable (refreshing the value is equivalent to creating a new identity)
+  - permitted to be displayed
+    - (Note: the value is somewhat display friendly, and may be appended to the displayName with a separating space, 
+      and used as a unique display name to be included in PKI Certificate DNs and as a resource ownership label, e.g. John Citizen ZsiAvfxa0BXULgcz7QXknbGtfxk)
+  - portable
+
+<br>
+
+See the [Support Portal Attributes page](https://support.aaf.edu.au/support/solutions/folders/19000156050) for complete information and definitions of the core, optional and conditional AAF attributes available.


### PR DESCRIPTION
Rapid Connect Claims had been added but the attributes were missing. This PR includes the addition of the attributes table and accompanying text.

Resolves https://github.com/ausaccessfed/dev-portal/issues/215


https://github.com/user-attachments/assets/73f66725-7ab5-4faf-abc9-8e2316988490


