### PR TITLE
Revert code block linting to improve accessibility

### DIFF
--- a/docs/_edugain-integration/02-software-version.md
+++ b/docs/_edugain-integration/02-software-version.md
@@ -63,7 +63,7 @@ To determine the version you are currently running:
 
 SimpleSAML_Configuration-class:
 
-```php
+```
 require_once('.../lib/_autoload.php');
 
 $cfg = SimpleSAML_Configuration::loadFromArray(array());

--- a/docs/_edugain-integration/03-edugain-metadata.md
+++ b/docs/_edugain-integration/03-edugain-metadata.md
@@ -27,7 +27,7 @@ Service Providers in the Production federation will use the <a href="https://md.
 
 The AAF digitally signs the eduGAIN metadata. A service MUST use the <a href="https://md.aaf.edu.au/aaf-metadata-certificate.pem">public key</a> to verify metadata documents whenever they are retrieved. To confirm that you have obtained the correct key, ensure the PEM file you have downloaded conforms to the following:
 
-```bash
+```
 $> openssl x509 -subject -dates -fingerprint -in aaf-metadata-certificate.pem
          subject= /O=Australian Access Federation/CN=AAF Metadata
          notBefore=Nov 24 04:27:20 2015 GMT
@@ -43,7 +43,7 @@ For a service provider using the Shibboleth SP software, the following changes t
 
 Add the following configuration element as a child element of the element:
 
-```xml
+```
 <MetadataProvider
 type="MDQ" id="mdq" ignoreTransport="true" cacheDirectory="metadata" baseUrl="https://md.test.aaf.edu.au/mdq/aaf_and_edugain/"
 reloadInterval="1800">

--- a/docs/_how-to-write-a-tutorial/04-add-a-new-tutorial.md
+++ b/docs/_how-to-write-a-tutorial/04-add-a-new-tutorial.md
@@ -9,7 +9,7 @@ last_updated: 17 October, 2025
 
 On the command line, the following rake task will set up the initial tutorial structure for you:
 
-```bash
+```
 bundle exec rake tutorial "Title of your tutorial"
 ```
 
@@ -26,7 +26,7 @@ bundle exec rake tutorial "Title of your tutorial"
 - You may want to include a "Next Steps" page at the end of your tutorial, which will be named `06-next-steps.md`. This page will guide the user on what to do next after completing your tutorial.
 - Each page needs to have the following front matter:
 
-    ```markdown
+    ```
     ---
     title: <page title>
     order: <number 1 to n for each page>
@@ -48,7 +48,7 @@ bundle exec rake tutorial "Title of your tutorial"
 - You will need to edit the metadata for your new tutorial in this file.
 - Add the following details to the new entry as shown below:
 
-    ```yaml
+    ```
       your-tutorial-id:
         output: true # do not change
         permalink: /:collection/:name # do not change

--- a/docs/_openid-connect-integration/03-openid-configuration.md
+++ b/docs/_openid-connect-integration/03-openid-configuration.md
@@ -12,7 +12,7 @@ Details for the **Test Federation** are here:
 
 <a href="https://central.test.aaf.edu.au/.well-known/openid-configuration" class="btn btn-primary mb-3">Test Federation</a>
 
-```bash
+```
 curl https://central.test.aaf.edu.au/.well-known/openid-configuration | jq
 
 {

--- a/docs/_openid-connect-integration/06-attribute-based-authorisation.md
+++ b/docs/_openid-connect-integration/06-attribute-based-authorisation.md
@@ -9,7 +9,7 @@ Specific attributes can be utilised to make authorisation decisions within an ap
 
 Below is an example of the ID Token attributes that are provided by the AAF OpenID Provider and translated to OpenID Connect:
   
-```json
+```
   {
     "sub": "YAdr3eQkhvnHrtOcdnOl4cFRdYnOmKoP4523eh45y89",
     "name": "John Doe",

--- a/docs/_rapid-connect-integration/06-examples.md
+++ b/docs/_rapid-connect-integration/06-examples.md
@@ -13,7 +13,7 @@ integration code. We have provided code written in Ruby, Python and PHP.
 
 ## Ruby
 
-```ruby
+```
   require 'sinatra'
   require 'json'
   require 'json/jwt'
@@ -68,7 +68,7 @@ integration code. We have provided code written in Ruby, Python and PHP.
 <br>
 ## Python
 
-```python
+```
   import webapp2
   import os
   import jwt
@@ -147,7 +147,7 @@ integration code. We have provided code written in Ruby, Python and PHP.
 
 ## PHP
 
-```php
+```
   <?php
   
   use JWT\Authentication\JWT;

--- a/docs/_rapid-connect-integration/09-attribute-based-authorisation.md
+++ b/docs/_rapid-connect-integration/09-attribute-based-authorisation.md
@@ -9,7 +9,7 @@ Specific claims within the ID token can be utilised to make authorisation decisi
 
 Below is an example of a decoded JWS for the user "John Doe" sent by Rapid Connect.
 
-```json
+```
 {
   "iat": 1516239022,
   "nbf": 1516239022,

--- a/docs/_saml-integration/04-install-shibboleth-example-b.md
+++ b/docs/_saml-integration/04-install-shibboleth-example-b.md
@@ -18,7 +18,7 @@ Please note, this is a proof of concept and only configures Shibboleth SP. Apach
 
 A Dockerfile is a text file that contains a set of instructions for building a Docker image. In this case, we are creating a Dockerfile for a Shibboleth-Service Provider application.
 
-```dockerfile
+```
 # Use Amazon Linux 2 as base image (alternative lightweight distributions include Debian, CentOS, Fedora or Ubuntu).
 FROM amazonlinux:2
 

--- a/docs/_verifid-integration/08-api-call.md
+++ b/docs/_verifid-integration/08-api-call.md
@@ -33,7 +33,7 @@ The request fields must be populated as follows:
 
 The response will be in JSON format, for example:
 
-```json
+```
 {
 "access_token": "2YotnFZFEjr1zCsicMWpAA",
 "token_type": "bearer",


### PR DESCRIPTION
## Description

<!-- Provide a clear description of your pull request. Make sure to include the tutorial title and a reason for your suggested changes/additions. If it is related to an issue, please reference the issue number, like `#1234`. -->

Linting the markdown files has reduced the accessibility for some of the code blocks. I've reverted those blocks that were affected.

<img width="1900" height="934" alt="Screenshot 2026-04-16 at 10 12 25" src="https://github.com/user-attachments/assets/75831d02-7a21-4e43-b299-1fea66318e88" />

<img width="1900" height="904" alt="Screenshot 2026-04-16 at 11 00 02" src="https://github.com/user-attachments/assets/4b7bdb67-c9de-4e76-a8b9-be512b74373e" />

