### PR TITLE
Increase colour contrast for code blocks

### DIFF
--- a/docs/assets/main.scss
+++ b/docs/assets/main.scss
@@ -70,6 +70,18 @@ pre, pre code {
   color: #ffe082 !important;
 }
 
+.highlight .mi { color: #FEB0FF !important; }
+
+.highlight .cp { color: #A8B5C8 !important; }
+
+.highlight .bp,
+.highlight .nb,
+.highlight .nc,
+.highlight .nf,
+.highlight .nn {
+  color: #5AF2FF !important;
+}
+
 .navbar {
   background-color: $aaf-dark-grey;
 }


### PR DESCRIPTION
## Description

<!-- Provide a clear description of your pull request. Make sure to include the tutorial title and a reason for your suggested changes/additions. If it is related to an issue, please reference the issue number, like `#1234`. -->

Specific token types have been targeted to increase the contrast of code blocks.

Resolves https://github.com/ausaccessfed/dev-portal/issues/225

From this:
<img width="1888" height="904" alt="Screenshot 2026-04-21 at 16 56 33" src="https://github.com/user-attachments/assets/7942b3d4-76f4-4f77-a1d5-39302f234c90" />


To this:
<img width="1888" height="904" alt="Screenshot 2026-04-21 at 16 54 35" src="https://github.com/user-attachments/assets/73dbef16-7c3f-4194-9fcc-de540612c941" />
