### PR TITLE
Add "Connect to Edugain" to SAML and Open ID Connect series tutorials 

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -28,7 +28,7 @@ defaults:
     values:
       layout: tutorial
 
-# Ordered by how they should appear in the curriculum list
+# Ordered by how they should appear in the curricula list
 tutorial_categories:
   - AAF Connection Types
   - Getting Started

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -47,7 +47,8 @@ collections:
     title: Connect with Keycloak
     summary: A tutorial for connecting with Keycloak
     category: Identity Management Solutions
-    curriculum: OpenID Connect
+    curricula:
+      - OpenID Connect
     level: Intermediate
     tags:
       - keycloak
@@ -95,7 +96,8 @@ collections:
     title: OpenID Connect Integration
     summary: A tutorial for OpenID Connect integration
     category: Integration
-    curriculum: OpenID Connect
+    curricula:
+      - OpenID Connect
     level: Intermediate
     tags:
       - openid connect
@@ -111,7 +113,8 @@ collections:
     title: Rapid Connect Integration
     summary: A tutorial for Rapid Connect integration
     category: Integration
-    curriculum: Rapid Connect
+    curricula:
+      - Rapid Connect
     level: Intermediate
     tags:
       - rapid connect
@@ -127,7 +130,8 @@ collections:
     title: SAML Integration
     summary: A tutorial for SAML integration
     category: Integration
-    curriculum: SAML
+    curricula:
+      - SAML
     level: Advanced
     tags:
       - saml
@@ -143,7 +147,8 @@ collections:
     title: Connect an OIDC Service
     summary: A tutorial for connecting an OIDC Service
     category: Connect a Service
-    curriculum: OpenID Connect
+    curricula:
+      - OpenID Connect
     level: Intermediate
     tags:
       - openid connect
@@ -159,7 +164,8 @@ collections:
     title: Connect a Rapid Connect Service
     summary: A tutorial for connecting a Rapid Connect service
     category: Connect a Service
-    curriculum: Rapid Connect
+    curricula:
+      - Rapid Connect
     level: Intermediate
     tags:
       - rapid connect
@@ -175,7 +181,8 @@ collections:
     title: Connect a SAML Service
     summary: A tutorial for connecting a SAML service
     category: Connect a Service
-    curriculum: SAML
+    curricula:
+      - SAML
     level: Intermediate
     tags:
       - saml
@@ -191,7 +198,8 @@ collections:
     title: VerifID Integration
     summary: A tutorial for VerifID integration
     category: Integration
-    curriculum: VerifID
+    curricula:
+      - VerifID
     level: Intermediate
     tags:
       - tutorial
@@ -207,7 +215,8 @@ collections:
     title: Connect with VerifID
     summary: A tutorial for connecting with VerifID
     category: Connect a Service
-    curriculum: VerifID
+    curricula:
+      - VerifID
     level: Intermediate
     tags:
       - tutorial
@@ -222,7 +231,8 @@ collections:
     permalink: /:collection/:name
     title: OpenID Connect Series
     summary: Integrate and connect with OIDC
-    curriculum: OpenID Connect
+    curricula:
+      - OpenID Connect
     level: Series
     tags:
       - series
@@ -237,7 +247,8 @@ collections:
     permalink: /:collection/:name
     title: Rapid Connect Series
     summary: Integrate and connect with Rapid Connect
-    curriculum: Rapid Connect
+    curricula:
+      - Rapid Connect
     level: Series
     tags:
       - series
@@ -252,7 +263,8 @@ collections:
     permalink: /:collection/:name
     title: VerifID Series
     summary: Integrate and connect with VerifID
-    curriculum: VerifID
+    curricula:
+      - VerifID
     level: Series
     tags:
       - series
@@ -267,7 +279,8 @@ collections:
     permalink: /:collection/:name
     title: SAML Series
     summary: Integrate and connect with SAML
-    curriculum: SAML
+    curricula:
+      - SAML
     level: Series
     tags:
       - series
@@ -283,7 +296,10 @@ collections:
     title: Connect to eduGAIN
     summary: A tutorial for connecting to eduGAIN
     category: Connect a Service
-    curriculum: eduGAIN
+    curricula:
+      - eduGAIN
+      - SAML
+      - OpenID Connect
     level: Beginner
     tags:
       - tutorial
@@ -299,7 +315,8 @@ collections:
     title: eduGAIN Integration
     summary: A tutorial for eduGAIN integration
     category: Integration
-    curriculum: eduGAIN
+    curricula:
+      - eduGAIN
     level: Advanced
     tags:
       - tutorial
@@ -314,7 +331,8 @@ collections:
     permalink: /:collection/:name
     title: eduGAIN Series
     summary: Integrate and connect with eduGAIN
-    curriculum: eduGAIN
+    curricula:
+      - eduGAIN
     level: Series
     tags:
       - series
@@ -330,7 +348,8 @@ collections:
     title: Introduction to eduGAIN
     summary: An overview of eduGAIN
     category: Getting Started
-    curriculum: eduGAIN
+    curricula:
+      - eduGAIN
     level: Intermediate
     tags:
       - tutorial
@@ -402,7 +421,8 @@ collections:
     title: Connect a single page OIDC service
     summary: A tutorial for connecting a single page OIDC service
     category: Connect a Service
-    curriculum: OpenID Connect
+    curricula:
+      - OpenID Connect
     level: Intermediate
     tags:
       - openid connect

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -279,7 +279,7 @@ collections:
     output: true
     permalink: /:collection/:name
     title: Connect to eduGAIN
-    summary: A tutorial for connecting to eduGAIN
+    summary: A tutorial for connecting a service to eduGAIN
     category: Connect a Service
     curricula:
       - eduGAIN

--- a/docs/_edugain-series/02-tutorials.md
+++ b/docs/_edugain-series/02-tutorials.md
@@ -7,7 +7,7 @@ last_updated: 24 October, 2025
 
 {% include tutorials.html -%}
 
-{% assign curriculum = "eduGAIN" %}
+{% assign series_name = "eduGAIN" %}
 
 {% comment %}
 To facilitate proper ordering of tutorials for eduGAIN series pages, we loop through our ordered list of categories and build the list of tutorials from there
@@ -16,11 +16,12 @@ To facilitate proper ordering of tutorials for eduGAIN series pages, we loop thr
 {% assign sortcategories = "" | split: "" %}
 
 {% comment %}
-Add categories used by tutorials with the assigned curriculum in the order specified in the site config
+Add categories used by tutorials with the assigned series in the order specified in the site config
 {% endcomment %}
 {% for category in site.tutorial_categories %}
 {% for tutorial in tutorials %}
-{% if tutorial.curriculum == curriculum and tutorial.category == category %}
+{% assign tutorial_curricula = tutorial.curricula | default: "" %}
+{% if tutorial_curricula contains series_name and tutorial.category == category %}
 {% unless sortcategories contains category %}
 {% assign sortcategories = sortcategories | push: category %}
 {% endunless %}
@@ -32,9 +33,10 @@ Add categories used by tutorials with the assigned curriculum in the order speci
 Add any missing categories to the end of the list
 {% endcomment %}
 {% for tutorial in tutorials %}
-{% if tutorial.curriculum == curriculum %}
+{% assign tutorial_curricula = tutorial.curricula | default: "" %}
+{% if tutorial_curricula contains series_name %}
 {% unless sortcategories contains tutorial.category %}
-{% assign sortcategories = sortcategories | push: category %}
+{% assign sortcategories = sortcategories | push: tutorial.category %}
 {% endunless %}
 {% endif %}
 {% endfor %}
@@ -49,7 +51,8 @@ The eduGAIN Series consists of the following tutorials, which you can work throu
 ## {{ category }}
 
 {% for tutorial in tutorials reversed %}
-{% if tutorial.curriculum == curriculum and tutorial.category == category %}
+{% assign tutorial_curricula = tutorial.curricula | default: "" %}
+{% if tutorial_curricula contains series_name and tutorial.category == category %}
 <div data-label="{{ tutorial.label }}" class="series-tutorial" markdown="1">
 ## [{{ tutorial.title }}]({{ tutorial.label | relative_url }})
 {{ tutorial.summary }}  

--- a/docs/_how-to-write-a-tutorial/04-add-a-new-tutorial.md
+++ b/docs/_how-to-write-a-tutorial/04-add-a-new-tutorial.md
@@ -182,6 +182,7 @@ This helps prevent any broken links in the future, if the central URL of the sit
 To easily generate a mailto link, go to this url: `https://mailtolinkgenerator.com/` and paste the generated link into the text using markdown syntax:
 
 Example:
+
 ```markdown
 <a href="mailto:hello@example.com?subject=Hello&body=Hi there!">Email us</a>
 ```

--- a/docs/_how-to-write-a-tutorial/04-add-a-new-tutorial.md
+++ b/docs/_how-to-write-a-tutorial/04-add-a-new-tutorial.md
@@ -54,13 +54,17 @@ bundle exec rake tutorial "Title of your tutorial"
         permalink: /:collection/:name # do not change
         title: <your tutorial title> # in less than 10 words
         summary: <tutorial description> # in less than 10 words
-        category: <choose one of Beginner, Intermediate, Advanced, Non-Technical or Curriculum>
+        category: <one of the values in `tutorial_categories` in `_config.yml`>
+        level: <Beginner|Intermediate|Advanced>
+        # Optional: include the tutorial in one-or-more Series pages
+        curricula:
+          - <e.g. SAML>
+          - <e.g. OpenID Connect>
         tags:
           - <keyword>
           - <keyword>
         difficulty: <number 1-5> # see below for difficulty levels
         duration: <number of minutes (in 5 minute intervals) your tutorial might take>
-        status: <draft or published> # do not change
         published: YYYY-MM-DD # do not change
         author: Your Name <your email address>
     ```
@@ -77,7 +81,7 @@ Use the following difficulty levels to categorise your tutorial:
 | 4     | Advanced (applied theory)            |
 | 5     | Advanced (recognized authority)      |
 
-After modifying the `config.yml` file, you will need to restart the preview process for Jekyll to render your new tutorial, but once it's done, it will be available from the `docs` folder of the site.
+After modifying the `_config.yml` file, you will need to restart the preview process for Jekyll to render your new tutorial, but once it's done, it will be available from the `docs` folder of the site.
 
 <br>
 

--- a/docs/_how-to-write-a-tutorial/04-add-a-new-tutorial.md
+++ b/docs/_how-to-write-a-tutorial/04-add-a-new-tutorial.md
@@ -65,6 +65,7 @@ bundle exec rake tutorial "Title of your tutorial"
           - <keyword>
         difficulty: <number 1-5> # see below for difficulty levels
         duration: <number of minutes (in 5 minute intervals) your tutorial might take>
+        status: <draft or published> # do not change
         published: YYYY-MM-DD # do not change
     ```
 

--- a/docs/_how-to-write-a-tutorial/04-add-a-new-tutorial.md
+++ b/docs/_how-to-write-a-tutorial/04-add-a-new-tutorial.md
@@ -174,3 +174,14 @@ For example `https://tutorials.aaf.edu.au/openid-connect-series/02-tutorials` wi
 >**\{\{ site.baseurl \}\}/openid-connect-series/02-tutorials**
 
 This helps prevent any broken links in the future, if the central URL of the site changes.
+
+<br>
+
+## Generating a mailto link
+
+To easily generate a mailto link, go to this url: `https://mailtolinkgenerator.com/` and paste the generated link into the text using markdown syntax:
+
+Example:
+```markdown
+<a href="mailto:hello@example.com?subject=Hello&body=Hi there!">Email us</a>
+```

--- a/docs/_layouts/tutorial.html
+++ b/docs/_layouts/tutorial.html
@@ -18,6 +18,20 @@ layout: default
   {% assign tmpprev = link %}
 {% endfor %}
 
+{%- comment -%}
+`curricula` is the canonical way to include a tutorial/collection in one-or-more
+Series curricula.
+
+Example:
+  curricula:
+    - OpenID Connect
+    - SAML
+{%- endcomment -%}
+{% assign curricula = "" | split: "" %}
+{% if collection.curricula %}
+  {% assign curricula = collection.curricula %}
+{% endif %}
+
 <div id="tutorial-page" class="container py-3 {% unless next %}last-page{% endunless %}" data-tut-name="{{ collection.label }}">
 
     <div class="d-block d-md-flex justify-content-between align-items-center pb-2 mb-3 border-bottom">
@@ -41,25 +55,32 @@ layout: default
     <div class="row">
       <div class="col-md-3 d-none d-md-block">
         <div class="sidebar py-3 sticky-top">
-          {% if collection.curriculum %}
+          {% if curricula.size > 0 %}
             <div class="sidebar-btn-link p-2">
-              <p class="mb-1"><i class="fa fa-info-circle"></i> This tutorial is part of the {{ collection.curriculum }} Series.</p>
-              {% if collection.curriculum == "OpenID Connect" %}
-              <a class="btn btn-link btn-md p-0"
-                 href="{{ '/openid-connect-series/02-tutorials' | prepend: site.baseurl }}"><i class="fa fa-arrow-left"></i> Back to OpenID Connect</a>
-              {% elsif collection.curriculum == "Rapid Connect" %}
-              <a class="btn btn-link btn-md p-0"
-                 href="{{ '/rapid-connect-series/02-tutorials' | prepend: site.baseurl }}"><i class="fa fa-arrow-left"></i> Back to Rapid Connect</a>
-              {% elsif collection.curriculum == "SAML" %}
-              <a class="btn btn-link btn-md p-0"
-                 href="{{ '/saml-series/02-tutorials' | prepend: site.baseurl }}"><i class="fa fa-arrow-left"></i> Back to SAML</a>
-              {% elsif collection.curriculum == "VerifID" %}
-              <a class="btn btn-link btn-md p-0"
-                 href="{{ '/verifid-series/02-tutorials' | prepend: site.baseurl }}"><i class="fa fa-arrow-left"></i> Back to VerifID</a>
-              {% elsif collection.curriculum == "eduGAIN" %}
-              <a class="btn btn-link btn-md p-0"
-                 href="{{ '/edugain-series/02-tutorials' | prepend: site.baseurl }}"><i class="fa fa-arrow-left"></i> Back to eduGAIN</a>
+              {% if curricula.size == 1 %}
+                <p class="mb-1"><i class="fa fa-info-circle"></i> This tutorial is part of the {{ curricula[0] }} Series.</p>
+              {% else %}
+                <p class="mb-1"><i class="fa fa-info-circle"></i> This tutorial is part of these series: {{ curricula | join: ", " }}.</p>
               {% endif %}
+
+              {% for curr in curricula %}
+                {% if curr == "OpenID Connect" %}
+                  <a class="btn btn-link btn-md p-0 d-block"
+                     href="{{ '/openid-connect-series/02-tutorials' | prepend: site.baseurl }}"><i class="fa fa-arrow-left"></i> Back to OpenID Connect</a>
+                {% elsif curr == "Rapid Connect" %}
+                  <a class="btn btn-link btn-md p-0 d-block"
+                     href="{{ '/rapid-connect-series/02-tutorials' | prepend: site.baseurl }}"><i class="fa fa-arrow-left"></i> Back to Rapid Connect</a>
+                {% elsif curr == "SAML" %}
+                  <a class="btn btn-link btn-md p-0 d-block"
+                     href="{{ '/saml-series/02-tutorials' | prepend: site.baseurl }}"><i class="fa fa-arrow-left"></i> Back to SAML</a>
+                {% elsif curr == "VerifID" %}
+                  <a class="btn btn-link btn-md p-0 d-block"
+                     href="{{ '/verifid-series/02-tutorials' | prepend: site.baseurl }}"><i class="fa fa-arrow-left"></i> Back to VerifID</a>
+                {% elsif curr == "eduGAIN" %}
+                  <a class="btn btn-link btn-md p-0 d-block"
+                     href="{{ '/edugain-series/02-tutorials' | prepend: site.baseurl }}"><i class="fa fa-arrow-left"></i> Back to eduGAIN</a>
+                {% endif %}
+              {% endfor %}
             </div>
           {% endif %}
           <div class="card mb-3 bg-dark shadow">
@@ -115,19 +136,21 @@ layout: default
           {% else %}
             <h2>Tutorial Complete!</h2>
             <p>You have completed this tutorial. Continue with the other tutorials in the {{ page.category }} Series or return to the tutorials home page.</p>
-            {% if collection.curriculum %}
-              {% if collection.curriculum == "OpenID Connect" %}
-                <a class="btn btn-secondary" href="{{ '/openid-connect-series/02-tutorials' | prepend: site.baseurl }}">Continue Series</a>
-              {% elsif collection.curriculum == "Rapid Connect" %}
-                <a class="btn btn-secondary" href="{{ '/rapid-connect-series/02-tutorials' | prepend: site.baseurl }}">Continue Series</a>
-              {% elsif collection.curriculum == "SAML" %}
-                <a class="btn btn-secondary" href="{{ '/saml-series/02-tutorials' | prepend: site.baseurl }}">Continue Series</a>
-              {% elsif collection.curriculum == "VerifID" %}
-                <a class="btn btn-secondary" href="{{ '/verifid-series/02-tutorials' | prepend: site.baseurl }}">Continue Series</a>
-              {% elsif collection.curriculum == "eduGAIN" %}
-                <a class="btn btn-secondary" href="{{ '/edugain-series/02-tutorials' | prepend: site.baseurl }}">Continue Series</a>
-              {% endif %}
-              {% endif %}
+            {% if curricula.size > 0 %}
+              {% for curr in curricula %}
+                {% if curr == "OpenID Connect" %}
+                  <a class="btn btn-secondary" href="{{ '/openid-connect-series/02-tutorials' | prepend: site.baseurl }}">Continue OpenID Connect Series</a>
+                {% elsif curr == "Rapid Connect" %}
+                  <a class="btn btn-secondary" href="{{ '/rapid-connect-series/02-tutorials' | prepend: site.baseurl }}">Continue Rapid Connect Series</a>
+                {% elsif curr == "SAML" %}
+                  <a class="btn btn-secondary" href="{{ '/saml-series/02-tutorials' | prepend: site.baseurl }}">Continue SAML Series</a>
+                {% elsif curr == "VerifID" %}
+                  <a class="btn btn-secondary" href="{{ '/verifid-series/02-tutorials' | prepend: site.baseurl }}">Continue VerifID Series</a>
+                {% elsif curr == "eduGAIN" %}
+                  <a class="btn btn-secondary" href="{{ '/edugain-series/02-tutorials' | prepend: site.baseurl }}">Continue eduGAIN Series</a>
+                {% endif %}
+              {% endfor %}
+            {% endif %}
             <a href="{{ site.baseurl }}/" class="btn btn-secondary" role="button">Return Home</a>
           {% endif %}
         {% endif %}

--- a/docs/_layouts/tutorial.html
+++ b/docs/_layouts/tutorial.html
@@ -63,24 +63,32 @@ Example:
                 <p class="mb-1"><i class="fa fa-info-circle"></i> This tutorial is part of these series: {{ curricula | join: ", " }}.</p>
               {% endif %}
 
+              {%- comment -%}
+              Render a single "Go Back" link even if the tutorial belongs to multiple curricula.
+              {%- endcomment -%}
+              {% assign back_url = nil %}
               {% for curr in curricula %}
-                {% if curr == "OpenID Connect" %}
-                  <a class="btn btn-link btn-md m-1 p-0 d-block"
-                     href="{{ '/openid-connect-series/02-tutorials' | prepend: site.baseurl }}"><i class="fa fa-arrow-left"></i> Back to OpenID Connect</a>
-                {% elsif curr == "Rapid Connect" %}
-                  <a class="btn btn-link btn-md m-1 p-0 d-block"
-                     href="{{ '/rapid-connect-series/02-tutorials' | prepend: site.baseurl }}"><i class="fa fa-arrow-left"></i> Back to Rapid Connect</a>
-                {% elsif curr == "SAML" %}
-                  <a class="btn btn-link btn-md m-1 p-0 d-block"
-                     href="{{ '/saml-series/02-tutorials' | prepend: site.baseurl }}"><i class="fa fa-arrow-left"></i> Back to SAML</a>
-                {% elsif curr == "VerifID" %}
-                  <a class="btn btn-link btn-md m-1 p-0 d-block"
-                     href="{{ '/verifid-series/02-tutorials' | prepend: site.baseurl }}"><i class="fa fa-arrow-left"></i> Back to VerifID</a>
-                {% elsif curr == "eduGAIN" %}
-                  <a class="btn btn-link btn-md m-1 p-0 d-block"
-                     href="{{ '/edugain-series/02-tutorials' | prepend: site.baseurl }}"><i class="fa fa-arrow-left"></i> Back to eduGAIN</a>
+                {% if back_url == nil %}
+                  {% case curr %}
+                    {% when "OpenID Connect" %}
+                      {% assign back_url = '/openid-connect-series/02-tutorials' %}
+                    {% when "Rapid Connect" %}
+                      {% assign back_url = '/rapid-connect-series/02-tutorials' %}
+                    {% when "SAML" %}
+                      {% assign back_url = '/saml-series/02-tutorials' %}
+                    {% when "VerifID" %}
+                      {% assign back_url = '/verifid-series/02-tutorials' %}
+                    {% when "eduGAIN" %}
+                      {% assign back_url = '/edugain-series/02-tutorials' %}
+                  {% endcase %}
                 {% endif %}
               {% endfor %}
+
+              {% if back_url %}
+                <a class="btn btn-link btn-md m-1 p-0 d-block" href="{{ back_url | prepend: site.baseurl }}">
+                  <i class="fa fa-arrow-left"></i> Go Back
+                </a>
+              {% endif %}
             </div>
           {% endif %}
           <div class="card mb-3 bg-dark shadow">

--- a/docs/_layouts/tutorial.html
+++ b/docs/_layouts/tutorial.html
@@ -65,19 +65,19 @@ Example:
 
               {% for curr in curricula %}
                 {% if curr == "OpenID Connect" %}
-                  <a class="btn btn-link btn-md p-0 d-block"
+                  <a class="btn btn-link btn-md m-1 p-0 d-block"
                      href="{{ '/openid-connect-series/02-tutorials' | prepend: site.baseurl }}"><i class="fa fa-arrow-left"></i> Back to OpenID Connect</a>
                 {% elsif curr == "Rapid Connect" %}
-                  <a class="btn btn-link btn-md p-0 d-block"
+                  <a class="btn btn-link btn-md m-1 p-0 d-block"
                      href="{{ '/rapid-connect-series/02-tutorials' | prepend: site.baseurl }}"><i class="fa fa-arrow-left"></i> Back to Rapid Connect</a>
                 {% elsif curr == "SAML" %}
-                  <a class="btn btn-link btn-md p-0 d-block"
+                  <a class="btn btn-link btn-md m-1 p-0 d-block"
                      href="{{ '/saml-series/02-tutorials' | prepend: site.baseurl }}"><i class="fa fa-arrow-left"></i> Back to SAML</a>
                 {% elsif curr == "VerifID" %}
-                  <a class="btn btn-link btn-md p-0 d-block"
+                  <a class="btn btn-link btn-md m-1 p-0 d-block"
                      href="{{ '/verifid-series/02-tutorials' | prepend: site.baseurl }}"><i class="fa fa-arrow-left"></i> Back to VerifID</a>
                 {% elsif curr == "eduGAIN" %}
-                  <a class="btn btn-link btn-md p-0 d-block"
+                  <a class="btn btn-link btn-md m-1 p-0 d-block"
                      href="{{ '/edugain-series/02-tutorials' | prepend: site.baseurl }}"><i class="fa fa-arrow-left"></i> Back to eduGAIN</a>
                 {% endif %}
               {% endfor %}
@@ -132,26 +132,26 @@ Example:
           {% if collection.level == 'Series' %}
             <h2>Series Complete!</h2>
             <p>You have completed this Series of Tutorials. Return to the tutorials home page to explore other tutorials.</p>
-            <a href="{{ site.baseurl }}/" class="btn bg-secondary text-white" role="button">Return Home</a>
+            <a href="{{ site.baseurl }}/" class="btn bg-secondary text-white m-1" role="button">Return Home</a>
           {% else %}
             <h2>Tutorial Complete!</h2>
             <p>You have completed this tutorial. Continue with the other tutorials in the {{ page.category }} Series or return to the tutorials home page.</p>
             {% if curricula.size > 0 %}
               {% for curr in curricula %}
                 {% if curr == "OpenID Connect" %}
-                  <a class="btn btn-secondary" href="{{ '/openid-connect-series/02-tutorials' | prepend: site.baseurl }}">Continue OpenID Connect Series</a>
+                  <a class="btn btn-secondary m-1" href="{{ '/openid-connect-series/02-tutorials' | prepend: site.baseurl }}">Continue OpenID Connect Series</a>
                 {% elsif curr == "Rapid Connect" %}
-                  <a class="btn btn-secondary" href="{{ '/rapid-connect-series/02-tutorials' | prepend: site.baseurl }}">Continue Rapid Connect Series</a>
+                  <a class="btn btn-secondary m-1" href="{{ '/rapid-connect-series/02-tutorials' | prepend: site.baseurl }}">Continue Rapid Connect Series</a>
                 {% elsif curr == "SAML" %}
-                  <a class="btn btn-secondary" href="{{ '/saml-series/02-tutorials' | prepend: site.baseurl }}">Continue SAML Series</a>
+                  <a class="btn btn-secondary m-1" href="{{ '/saml-series/02-tutorials' | prepend: site.baseurl }}">Continue SAML Series</a>
                 {% elsif curr == "VerifID" %}
-                  <a class="btn btn-secondary" href="{{ '/verifid-series/02-tutorials' | prepend: site.baseurl }}">Continue VerifID Series</a>
+                  <a class="btn btn-secondary m-1" href="{{ '/verifid-series/02-tutorials' | prepend: site.baseurl }}">Continue VerifID Series</a>
                 {% elsif curr == "eduGAIN" %}
-                  <a class="btn btn-secondary" href="{{ '/edugain-series/02-tutorials' | prepend: site.baseurl }}">Continue eduGAIN Series</a>
+                  <a class="btn btn-secondary m-1" href="{{ '/edugain-series/02-tutorials' | prepend: site.baseurl }}">Continue eduGAIN Series</a>
                 {% endif %}
               {% endfor %}
             {% endif %}
-            <a href="{{ site.baseurl }}/" class="btn btn-secondary" role="button">Return Home</a>
+            <a href="{{ site.baseurl }}/" class="btn btn-secondary m-1" role="button">Return Home</a>
           {% endif %}
         {% endif %}
       </div>

--- a/docs/_layouts/tutorial.html
+++ b/docs/_layouts/tutorial.html
@@ -19,14 +19,14 @@ layout: default
 {% endfor %}
 
 {%- comment -%}
-`curricula` is the canonical way to include a tutorial/collection in one-or-more
-Series curricula.
+To include a tutorial/collection in one-or-more Series curricula, edit `curricula` in the tutorial's front matter.
 
 Example:
   curricula:
     - OpenID Connect
     - SAML
 {%- endcomment -%}
+
 {% assign curricula = "" | split: "" %}
 {% if collection.curricula %}
   {% assign curricula = collection.curricula %}

--- a/docs/_openid-connect-series/02-tutorials.md
+++ b/docs/_openid-connect-series/02-tutorials.md
@@ -7,7 +7,7 @@ last_updated: 24 October, 2025
 
 {% include tutorials.html -%}
 
-{% assign curriculum = "OpenID Connect" %}
+{% assign series_name = "OpenID Connect" %}
 
 {% comment %}
 To facilitate proper ordering of tutorials for openid connect series pages, we loop through our ordered list of categories and build the list of tutorials from there
@@ -16,12 +16,13 @@ To facilitate proper ordering of tutorials for openid connect series pages, we l
 {% assign sortcategories = "" | split: "" %}
 
 {% comment %}
-Add categories used by tutorials with the assigned curriculum in the order
+Add categories used by tutorials with the assigned series in the order
 specified in the site config
 {% endcomment %}
 {% for category in site.tutorial_categories %}
 {% for tutorial in tutorials %}
-{% if tutorial.curriculum == curriculum and tutorial.category == category %}
+{% assign tutorial_curricula = tutorial.curricula | default: "" %}
+{% if tutorial_curricula contains series_name and tutorial.category == category %}
 {% unless sortcategories contains category %}
 {% assign sortcategories = sortcategories | push: category %}
 {% endunless %}
@@ -33,9 +34,10 @@ specified in the site config
 Add any missing categories to the end of the list
 {% endcomment %}
 {% for tutorial in tutorials %}
-{% if tutorial.curriculum == curriculum %}
+{% assign tutorial_curricula = tutorial.curricula | default: "" %}
+{% if tutorial_curricula contains series_name %}
 {% unless sortcategories contains tutorial.category %}
-{% assign sortcategories = sortcategories | push: category %}
+{% assign sortcategories = sortcategories | push: tutorial.category %}
 {% endunless %}
 {% endif %}
 {% endfor %}
@@ -50,7 +52,8 @@ The OpenID Connect Series consists of the following tutorials, which you can wor
 ## {{ category }}
 
 {% for tutorial in tutorials reversed %}
-{% if tutorial.curriculum == curriculum and tutorial.category == category %}
+{% assign tutorial_curricula = tutorial.curricula | default: "" %}
+{% if tutorial_curricula contains series_name and tutorial.category == category %}
 <div data-label="{{ tutorial.label }}" class="series-tutorial" markdown="1">
 ## [{{ tutorial.title }}]({{ tutorial.label | relative_url }})
 {{ tutorial.summary }}  

--- a/docs/_rapid-connect-series/02-tutorials.md
+++ b/docs/_rapid-connect-series/02-tutorials.md
@@ -7,7 +7,7 @@ last_updated: 24 October, 2025
 
 {% include tutorials.html -%}
 
-{% assign curriculum = "Rapid Connect" %}
+{% assign series_name = "Rapid Connect" %}
 
 {% comment %}
 To facilitate proper ordering of tutorials for rapid connect series pages, we loop
@@ -17,12 +17,13 @@ through our ordered list of categories and build the list of tutorials from ther
 {% assign sortcategories = "" | split: "" %}
 
 {% comment %}
-Add categories used by tutorials with the assigned curriculum in the order
+Add categories used by tutorials with the assigned series in the order
 specified in the site config
 {% endcomment %}
 {% for category in site.tutorial_categories %}
 {% for tutorial in tutorials %}
-{% if tutorial.curriculum == curriculum and tutorial.category == category %}
+{% assign tutorial_curricula = tutorial.curricula | default: "" %}
+{% if tutorial_curricula contains series_name and tutorial.category == category %}
 {% unless sortcategories contains category %}
 {% assign sortcategories = sortcategories | push: category %}
 {% endunless %}
@@ -34,9 +35,10 @@ specified in the site config
 Add any missing categories to the end of the list
 {% endcomment %}
 {% for tutorial in tutorials %}
-{% if tutorial.curriculum == curriculum %}
+{% assign tutorial_curricula = tutorial.curricula | default: "" %}
+{% if tutorial_curricula contains series_name %}
 {% unless sortcategories contains tutorial.category %}
-{% assign sortcategories = sortcategories | push: category %}
+{% assign sortcategories = sortcategories | push: tutorial.category %}
 {% endunless %}
 {% endif %}
 {% endfor %}
@@ -51,7 +53,8 @@ The Rapid Connect Series consists of the following tutorials, which you can work
 ## {{ category }}
 
 {% for tutorial in tutorials reversed %}
-{% if tutorial.curriculum == curriculum and tutorial.category == category %}
+{% assign tutorial_curricula = tutorial.curricula | default: "" %}
+{% if tutorial_curricula contains series_name and tutorial.category == category %}
 <div data-label="{{ tutorial.label }}" class="series-tutorial" markdown="1">
 #### [{{ tutorial.title }}]({{ tutorial.label | relative_url }})
 {{ tutorial.summary }}  

--- a/docs/_saml-series/02-tutorials.md
+++ b/docs/_saml-series/02-tutorials.md
@@ -7,7 +7,7 @@ last_updated: 24 October, 2025
 
 {% include tutorials.html -%}
 
-{% assign curriculum = "SAML" %}
+{% assign series_name = "SAML" %}
 
 {% comment %}
 To facilitate proper ordering of tutorials for saml series pages, we loop through our ordered list of categories and build the list of tutorials from there
@@ -16,12 +16,13 @@ To facilitate proper ordering of tutorials for saml series pages, we loop throug
 {% assign sortcategories = "" | split: "" %}
 
 {% comment %}
-Add categories used by tutorials with the assigned curriculum in the order
+Add categories used by tutorials with the assigned series in the order
 specified in the site config
 {% endcomment %}
 {% for category in site.tutorial_categories %}
 {% for tutorial in tutorials %}
-{% if tutorial.curriculum == curriculum and tutorial.category == category %}
+{% assign tutorial_curricula = tutorial.curricula | default: "" %}
+{% if tutorial_curricula contains series_name and tutorial.category == category %}
 {% unless sortcategories contains category %}
 {% assign sortcategories = sortcategories | push: category %}
 {% endunless %}
@@ -33,9 +34,10 @@ specified in the site config
 Add any missing categories to the end of the list
 {% endcomment %}
 {% for tutorial in tutorials %}
-{% if tutorial.curriculum == curriculum %}
+{% assign tutorial_curricula = tutorial.curricula | default: "" %}
+{% if tutorial_curricula contains series_name %}
 {% unless sortcategories contains tutorial.category %}
-{% assign sortcategories = sortcategories | push: category %}
+{% assign sortcategories = sortcategories | push: tutorial.category %}
 {% endunless %}
 {% endif %}
 {% endfor %}
@@ -50,7 +52,8 @@ The SAML Series consists of the following tutorials, which you can work through 
 ## {{ category }}
 
 {% for tutorial in tutorials reversed %}
-{% if tutorial.curriculum == curriculum and tutorial.category == category %}
+{% assign tutorial_curricula = tutorial.curricula | default: "" %}
+{% if tutorial_curricula contains series_name and tutorial.category == category %}
 <div data-label="{{ tutorial.label }}" class="series-tutorial" markdown="1">
 #### [{{ tutorial.title }}]({{ tutorial.label | relative_url }})
 {{ tutorial.summary }}  

--- a/docs/_verifid-series/02-tutorials.md
+++ b/docs/_verifid-series/02-tutorials.md
@@ -7,7 +7,7 @@ last_updated: 24 October, 2025
 
 {% include tutorials.html -%}
 
-{% assign curriculum = "VerifID" %}
+{% assign series_name = "VerifID" %}
 
 {% comment %}
 To facilitate proper ordering of tutorials for verifid series pages, we loop through our ordered list of categories and build the list of tutorials from there
@@ -16,11 +16,12 @@ To facilitate proper ordering of tutorials for verifid series pages, we loop thr
 {% assign sortcategories = "" | split: "" %}
 
 {% comment %}
-Add categories used by tutorials with the assigned curriculum in the order specified in the site config
+Add categories used by tutorials with the assigned series in the order specified in the site config
 {% endcomment %}
 {% for category in site.tutorial_categories %}
 {% for tutorial in tutorials %}
-{% if tutorial.curriculum == curriculum and tutorial.category == category %}
+{% assign tutorial_curricula = tutorial.curricula | default: "" %}
+{% if tutorial_curricula contains series_name and tutorial.category == category %}
 {% unless sortcategories contains category %}
 {% assign sortcategories = sortcategories | push: category %}
 {% endunless %}
@@ -32,9 +33,10 @@ Add categories used by tutorials with the assigned curriculum in the order speci
 Add any missing categories to the end of the list
 {% endcomment %}
 {% for tutorial in tutorials %}
-{% if tutorial.curriculum == curriculum %}
+{% assign tutorial_curricula = tutorial.curricula | default: "" %}
+{% if tutorial_curricula contains series_name %}
 {% unless sortcategories contains tutorial.category %}
-{% assign sortcategories = sortcategories | push: category %}
+{% assign sortcategories = sortcategories | push: tutorial.category %}
 {% endunless %}
 {% endif %}
 {% endfor %}
@@ -49,7 +51,8 @@ The VerifID Series consists of the following tutorials, which you can work throu
 ## {{ category }}
 
 {% for tutorial in tutorials reversed %}
-{% if tutorial.curriculum == curriculum and tutorial.category == category %}
+{% assign tutorial_curricula = tutorial.curricula | default: "" %}
+{% if tutorial_curricula contains series_name and tutorial.category == category %}
 <div data-label="{{ tutorial.label }}" class="series-tutorial" markdown="1">
 #### [{{ tutorial.title }}]({{ tutorial.label | relative_url }})
 {{ tutorial.summary }}  


### PR DESCRIPTION
## Description

<!-- Provide a clear description of your pull request. Make sure to include the tutorial title and a reason for your suggested changes/additions. If it is related to an issue, please reference the issue number, like `#1234`. -->

This PR adds the "Connect to EduGAIN" tutorial link to the OpenID Connect and SAML series. This required allowing more than one curriculum (i.e. eduGAIN, SAML and OpenID Connect) for the "Connect to EduGAIN" tutorial. This will also allow future tutorials to also have more than one curriculum. Instructions for using a mailto link have also been added.

Resolves https://github.com/ausaccessfed/dev-portal/issues/216

https://github.com/user-attachments/assets/e3ce20f2-c31d-4378-ab80-d28340949d88


